### PR TITLE
fix: tk_base.rc error reported when using the WIN64 -dyn tclkit file.

### DIFF
--- a/sources/kbskit0.4/generic/kitInit.c
+++ b/sources/kbskit0.4/generic/kitInit.c
@@ -35,9 +35,13 @@
 #include <string.h>
 
 #ifdef _WIN32
+#define UNICODE
+#define _UNICODE
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
+#include <tclWinInt.h>
+#include <tkWin.h>
 #endif
 
 /* defined in tclInt.h */


### PR DESCRIPTION
Closes #1